### PR TITLE
Issue #109: Stop the test suite from provisioning billable AWS resources

### DIFF
--- a/.github/workflows/real_world_tests.yml
+++ b/.github/workflows/real_world_tests.yml
@@ -129,7 +129,11 @@ jobs:
       
       - name: Run unit tests
         run: |
-          pytest tests/unit/ tests/integration/ -v \
+          # tests/integration/ is deliberately excluded: it provisions real,
+          # billable cloud resources and is gated behind CLUSTRIX_ALLOW_BILLABLE
+          # (see #109). This job is named "No Infrastructure" -- targeting that
+          # directory here contradicted its own purpose.
+          pytest tests/unit/ -v \
             -m "not real_world" \
             --cov=clustrix \
             --cov-report=xml \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,11 +38,16 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[dev,test,kubernetes,widget]"
 
+    # Linting is version-independent, so run it once on the primary target
+    # rather than on all 13 matrix combinations. This also keeps the black pin
+    # off Python 3.8, which black 25.1.0 does not support (see #110).
     - name: Lint with black
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
       run: |
         black --check clustrix/ tests/
 
     - name: Lint with flake8
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
       run: |
         flake8 clustrix/ tests/ --max-line-length=88 --extend-ignore=E203,W503,F401,E722,F541,F841,F811,E731,E501,W291,W293,F824 --exit-zero
 

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ docs/build/
 
 # ClaudPoint checkpoint system
 .checkpoints/
+
+# CCPM settings backups - contain local credentials, must never be committed (see #111)
+.ccpm_backup/

--- a/notes/audit_and_master_plan_2026-08-17.md
+++ b/notes/audit_and_master_plan_2026-08-17.md
@@ -1,0 +1,90 @@
+# Clustrix full audit + master plan — 2026-08-17
+
+Session goal: explore the package thoroughly, triage all open GitHub issues, open a master plan
+for production readiness plus sub-issues. Five parallel read-only audits were run (source tree,
+test suite actually executed, all open issues, docs, security).
+
+## Outcome
+
+- **Master plan: #108** with **19 sub-issues (#109–#127)**, all linked via GitHub sub-issue API.
+- **9 issues closed**, **11 issues updated** with evidence-cited corrections.
+- Open issues went 29 → 40 (net +11: 9 closed, 20 opened).
+- Nothing in the working tree was modified. No code changes made.
+
+## Headline audit findings (all evidence-cited in #108)
+
+| Area | Finding |
+|-|-|
+| Test run | `127 failed, 1738 passed, 26 skipped, 8 errors in 134.78s` |
+| CI | Runs **15 of 2,280 tests** (~0.7%). `tests/unit/` only. |
+| Coverage | 4 conflicting numbers: 74% (planning, unreproducible) / 5.69% (stale artifact) / 8.21% (CI scope) / 56.14% (full suite) |
+| Mocks | 60/240 test files, **2,513 occurrences**; 3 inside `tests/real_world/` |
+| Prod mock-awareness | `executor_scheduler_status.py:89` branches on `isinstance(ssh_client, Mock)`; `notebook_magic_mocks.py` imported by 6 prod modules |
+| Dead code | ~5,100 lines (13%) with zero importers |
+| Backends | ssh COMPLETE; slurm/sge/k8s/local PARTIAL; **pbs BROKEN**; **all cloud BROKEN/STUB** |
+| Security | #107 was a FALSE POSITIVE. Real issue: unauthenticated pickle of remote results = remote→local RCE |
+| Git | master was **30 commits ahead of origin** (unpushed epic #98 work) |
+
+### Landmine (highest urgency)
+`tests/integration/` has **zero pytest markers**, so `pytest -m "not real_world"` — the documented
+unit-test command — selects `test_aws_eks_real_provision.py` ("this WILL create resources and incur
+costs!"). Confirmed via `lsof`: ESTABLISHED connections to `ec2-*.compute-1.amazonaws.com:443`.
+→ **#109**
+
+### The structural pattern
+Nearly every "done" item is half-done the same way: **scaffolding landed, seam did not.**
+- closure vars detected + injected (`function_flattening.py:623,654-695`) but never passed (`:749-751`)
+- REPL limit documented (`README.md:554`) but code still fails opaquely (`utils.py:118-119`)
+- k8s provisioners exist but GCP `_assign_iam_role()` assigns nothing (`gcp_provisioner.py:356`)
+- cloud path: `utils.py:151` writes `{"function":...}`, `executor_cloud.py:390` reads `['func']`
+  → unconditional KeyError. Proof the path never ran.
+
+## HuggingFace Jobs — VERIFIED WORKING (new capability)
+
+Verified end-to-end today: real container ran, returned `CLUSTRIX_HF_OK 3.12.14 x86_64`.
+
+- Namespace: **`contextlab`** (org, plan `academia`). Personal namespace gives `402 Payment Required`.
+- Token must be **fine-grained with `job.write` scoped to the ORG**, not just the user.
+  User-only scope → `403 missing permissions: job.write` on the org namespace.
+- Diagnostic: `403` = token can't act here; `402` = token fine, nobody's paying.
+- Flavors: `cpu-basic … h100x8`.
+- `hf jobs run --namespace contextlab --flavor cpu-basic python:3.12-slim python -c "..."`
+
+Strategic point: clustrix targets HF **Spaces** (wrong primitive, long-lived web apps) and it's a
+stub. HF **Jobs** matches clustrix's model exactly. → **#118**
+
+## Issue triage performed
+
+| Action | Issues |
+|-|-|
+| Closed — false positive | #107 |
+| Closed — completed | #85 (SGE fully implemented), #82, #72 |
+| Closed — superseded/dup | #61 (dup of #98), #86 (dup of #99+#102) |
+| Closed — archival | #92, #93, #94 |
+| Updated | #66, #68, #88, #89, #90, #91, #95, #98, #99, #100, #101, #102, #103, #104, #105, #106 |
+
+## Recommended order of attack (from #108 §9)
+
+1. **#109 alone first** — only issue with ongoing cost if ignored.
+2. #110 → #114 → #113 (runnable → green → CI on). Turning CI on before #114 makes master
+   permanently red and invites re-adding `continue-on-error`.
+3. #116 before #117 (remove prod mock-awareness before rewriting tests).
+4. #122 before #115 (delete dead code before baselining coverage).
+5. #118 early — unblocks honest testing for #119, #120, #126.
+
+## Open decisions for the user
+
+- **#112**: what to do with the 30 unpushed commits. Recommended (b): push to
+  `epic/test-coverage-90-percent` branch + PR, rather than merging ~2,500 mock occurrences into
+  master right before #117 removes them.
+- **#111**: rotate HF tokens `hf_Fbf…` / `hf_hSV…` (local-only, never on GitHub — verified 3 ways),
+  and enable GitHub secret scanning + push protection (currently disabled on this public repo).
+
+## Verification commands used
+
+```bash
+git rev-list --left-right --count origin/master...master     # 0  30
+grep -rc "pytest.mark" tests/integration/                    # 0 for every file
+gh api repos/ContextLab/clustrix/secret-scanning/alerts      # 404 = disabled
+gh api repos/ContextLab/clustrix/issues/108/sub_issues --jq 'length'   # 19
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ cloud = [
 dev = [
     "pytest>=6.0",
     "pytest-cov>=2.0",
-    "black==25.1.0",  # pinned - unbounded ">=" let CI pull black 26.5.1 (see #110)
+    "black==25.1.0; python_version >= '3.9'",  # pinned - unbounded ">=" let CI pull 26.5.1 (see #110)
     "flake8>=3.8", 
     "mypy>=0.812",
     "types-PyYAML",
@@ -132,7 +132,7 @@ all = [
     # Development dependencies
     "pytest>=6.0",
     "pytest-cov>=2.0",
-    "black==25.1.0",  # pinned - unbounded ">=" let CI pull black 26.5.1 (see #110)
+    "black==25.1.0; python_version >= '3.9'",  # pinned - unbounded ">=" let CI pull 26.5.1 (see #110)
     "flake8>=3.8",
     "mypy>=0.812",
     # Documentation dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ cloud = [
 dev = [
     "pytest>=6.0",
     "pytest-cov>=2.0",
-    "black>=21.0",
+    "black==25.1.0",  # pinned - unbounded ">=" let CI pull black 26.5.1 (see #110)
     "flake8>=3.8", 
     "mypy>=0.812",
     "types-PyYAML",
@@ -132,7 +132,7 @@ all = [
     # Development dependencies
     "pytest>=6.0",
     "pytest-cov>=2.0",
-    "black>=21.0",
+    "black==25.1.0",  # pinned - unbounded ">=" let CI pull black 26.5.1 (see #110)
     "flake8>=3.8",
     "mypy>=0.812",
     # Documentation dependencies

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,56 @@
+import os
+import pathlib
 import pytest
 import tempfile
 import shutil
 from unittest.mock import Mock, patch
 from clustrix.config import ClusterConfig, configure
+
+_INTEGRATION_DIR = (pathlib.Path(__file__).parent / "integration").resolve()
+_OPT_IN_VAR = "CLUSTRIX_ALLOW_BILLABLE"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _billable_tests_enabled():
+    return os.environ.get(_OPT_IN_VAR, "").strip().lower() in _TRUTHY
+
+
+def pytest_configure(config):
+    """Refuse to start when a run explicitly targets tests/integration.
+
+    See issue #109. `tests/integration/conftest.py` sets `collect_ignore_glob`,
+    which keeps the directory out of ordinary runs -- but that only filters
+    *directory traversal*. A path named explicitly as a pytest argument is not
+    filtered by it, so
+
+        pytest tests/integration/test_timeout_mechanism.py
+
+    collected and imported the module anyway. Those modules reach real cloud
+    APIs, so the check has to happen before collection begins.
+
+    This runs at configure time, which is before any test module is imported.
+
+    Deliberately scoped to *explicit* targeting: a plain `pytest tests/` must
+    keep working and silently skip the directory, while someone who asked for
+    these tests by name gets told why they got nothing, rather than an
+    inscrutable empty run.
+    """
+    if _billable_tests_enabled():
+        return
+    for arg in config.args:
+        # strip pytest's "::TestClass::test_name" node-id suffix
+        candidate = pathlib.Path(str(arg).split("::")[0])
+        if not candidate.is_absolute():
+            candidate = (pathlib.Path(str(config.rootpath)) / candidate).resolve()
+        else:
+            candidate = candidate.resolve()
+        if candidate == _INTEGRATION_DIR or _INTEGRATION_DIR in candidate.parents:
+            raise pytest.UsageError(
+                f"Refusing to run {arg!r}: tests/integration provisions real, "
+                f"billable cloud resources (AWS EKS/EC2). Set {_OPT_IN_VAR}=1 to "
+                f"run them deliberately, e.g.\n"
+                f"    {_OPT_IN_VAR}=1 pytest {arg}"
+            )
 
 
 @pytest.fixture

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,65 @@
+"""Opt-in gate for the integration test suite.
+
+See issue #109.
+
+Everything in this directory talks to external infrastructure, and a large
+subset provisions **billable** cloud resources (AWS EKS clusters, EC2
+instances, GPU nodes). Before this gate existed, the documented command
+``pytest tests/ -m "not real_world"`` collected this directory, because none of
+its files carried a pytest marker.
+
+A marker-based skip would not be sufficient. pytest must *import* a module in
+order to collect it, and several modules here are standalone scripts rather
+than test modules -- ``test_eks_permissions.py`` and ``test_aws_eks_debug.py``
+fetch credentials, call boto3, and invoke ``exit()`` at module scope. Importing
+them is itself the harm:
+
+* the AWS calls happen before any marker or skip is consulted, and
+* the module-level ``sys.exit(1)`` raises ``SystemExit`` during collection,
+  which crashes the whole pytest run with ``INTERNALERROR``.
+
+So the gate has to stop *collection*, which is what ``collect_ignore_glob``
+does -- pytest never imports an ignored file.
+
+The gate is deliberately directory-wide (default-deny) rather than a
+per-file allowlist. Misclassifying one file out of ~48 costs real money, and a
+newly added file must not be able to run for free simply because nobody
+remembered to mark it.
+
+To run these tests deliberately::
+
+    CLUSTRIX_ALLOW_BILLABLE=1 pytest tests/integration/
+
+Be aware that doing so may create real, chargeable cloud resources.
+"""
+
+import os
+
+import pytest
+
+OPT_IN_VAR = "CLUSTRIX_ALLOW_BILLABLE"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def billable_tests_enabled() -> bool:
+    """Return True only if the operator explicitly opted in to paying."""
+    return os.environ.get(OPT_IN_VAR, "").strip().lower() in _TRUTHY
+
+
+# Prevent pytest from importing anything in this directory unless opted in.
+# This must stay at module scope: conftest collect_ignore hooks are read when
+# the directory is first visited, before any test module is imported.
+if not billable_tests_enabled():
+    collect_ignore_glob = ["*.py"]
+
+
+def pytest_collection_modifyitems(config, items):
+    """Mark everything here as integration + expensive when it does run.
+
+    Only reachable under opt-in (otherwise nothing is collected). This keeps
+    ``-m`` selection meaningful for anyone who has opted in, e.g.
+    ``-m "not expensive"`` to run the cheaper integration tests.
+    """
+    for item in items:
+        item.add_marker(pytest.mark.integration)
+        item.add_marker(pytest.mark.expensive)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -34,6 +34,7 @@ Be aware that doing so may create real, chargeable cloud resources.
 """
 
 import os
+import pathlib
 
 import pytest
 
@@ -53,13 +54,26 @@ if not billable_tests_enabled():
     collect_ignore_glob = ["*.py"]
 
 
-def pytest_collection_modifyitems(config, items):
-    """Mark everything here as integration + expensive when it does run.
+_THIS_DIR = pathlib.Path(__file__).parent.resolve()
 
-    Only reachable under opt-in (otherwise nothing is collected). This keeps
-    ``-m`` selection meaningful for anyone who has opted in, e.g.
+
+def pytest_collection_modifyitems(config, items):
+    """Mark tests *from this directory* as integration + expensive.
+
+    Only reachable under opt-in (otherwise nothing here is collected). This
+    keeps ``-m`` selection meaningful for anyone who has opted in, e.g.
     ``-m "not expensive"`` to run the cheaper integration tests.
+
+    The path filter is essential and easy to get wrong: pytest passes the
+    hook the **entire session's** item list, not just items collected from
+    this directory. Marking unconditionally would tag every test in the whole
+    suite as `expensive`, so `-m "not expensive"` would select nothing at all.
     """
     for item in items:
-        item.add_marker(pytest.mark.integration)
-        item.add_marker(pytest.mark.expensive)
+        try:
+            item_path = pathlib.Path(str(item.fspath)).resolve()
+        except Exception:  # pragma: no cover - defensive, path may be virtual
+            continue
+        if item_path == _THIS_DIR or _THIS_DIR in item_path.parents:
+            item.add_marker(pytest.mark.integration)
+            item.add_marker(pytest.mark.expensive)

--- a/tests/integration/test_aws_eks_debug.py
+++ b/tests/integration/test_aws_eks_debug.py
@@ -1,66 +1,91 @@
 #!/usr/bin/env python
-"""Debug AWS EKS provisioning - test initial steps only."""
+"""Debug AWS EKS provisioning - test initial steps only.
+
+This file is a diagnostic *script*, not a pytest module: it contains no test
+functions. Its body previously ran at module scope, which meant that merely
+importing it fetched real AWS credentials, constructed a boto3 client, called
+the EKS API, and could `sys.exit(1)` mid-collection (crashing pytest with
+INTERNALERROR).
+
+The body now lives in `main()` behind a `__main__` guard so that importing this
+module is inert. See issue #109: the directory-level gate in conftest.py does
+not protect against a path being named explicitly on the pytest command line,
+because collect_ignore_glob only filters directory traversal.
+
+Run deliberately with:
+
+    python tests/integration/test_aws_eks_debug.py
+"""
 
 import sys
 import traceback
+
 from clustrix.kubernetes.aws_provisioner import AWSEKSFromScratchProvisioner
 from clustrix.kubernetes.cluster_provisioner import ClusterSpec
 from clustrix.credential_manager import FlexibleCredentialManager
 
-# Get credentials
-print("Getting AWS credentials...")
-credential_manager = FlexibleCredentialManager()
-aws_creds = credential_manager.ensure_credential("aws")
 
-if not aws_creds:
-    print("❌ No AWS credentials found")
-    sys.exit(1)
+def main():
+    # Get credentials
+    print("Getting AWS credentials...")
+    credential_manager = FlexibleCredentialManager()
+    aws_creds = credential_manager.ensure_credential("aws")
 
-print(f"✅ Got credentials for account: {aws_creds.get('account_id', 'unknown')}")
-print(f"   Region: {aws_creds.get('region', 'us-east-1')}")
+    if not aws_creds:
+        print("❌ No AWS credentials found")
+        return 1
 
-# Create spec
-spec = ClusterSpec(
-    cluster_name="test-debug",
-    provider="aws",
-    region=aws_creds.get("region", "us-east-1"),
-    node_count=1,
-    node_type="t3.small",
-    kubernetes_version="1.27",
-)
+    print(f"✅ Got credentials for account: {aws_creds.get('account_id', 'unknown')}")
+    print(f"   Region: {aws_creds.get('region', 'us-east-1')}")
 
-print(f"\nCluster spec created: {spec.cluster_name}")
-
-# Initialize provisioner
-print("\nInitializing provisioner...")
-try:
-    provisioner = AWSEKSFromScratchProvisioner(aws_creds, spec.region)
-    print("✅ Provisioner initialized")
-
-    # Check AWS connectivity
-    print("\nTesting AWS connectivity...")
-    import boto3
-
-    eks = boto3.client(
-        "eks",
-        aws_access_key_id=aws_creds["access_key_id"],
-        aws_secret_access_key=aws_creds["secret_access_key"],
-        region_name=spec.region,
+    # Create spec
+    spec = ClusterSpec(
+        cluster_name="test-debug",
+        provider="aws",
+        region=aws_creds.get("region", "us-east-1"),
+        node_count=1,
+        node_type="t3.small",
+        kubernetes_version="1.27",
     )
 
-    clusters = eks.list_clusters()
-    print(f"✅ Can list EKS clusters. Found: {clusters.get('clusters', [])}")
+    print(f"\nCluster spec created: {spec.cluster_name}")
 
-    # Test VPC creation
-    print("\nWould create VPC with:")
-    print(f"  - Name: eks-vpc-{spec.cluster_name}")
-    print(f"  - CIDR: 10.0.0.0/16")
-    print(f"  - Region: {spec.region}")
+    # Initialize provisioner
+    print("\nInitializing provisioner...")
+    try:
+        provisioner = AWSEKSFromScratchProvisioner(aws_creds, spec.region)
+        print("✅ Provisioner initialized")
+        print(f"   Provisioner: {provisioner}")
 
-except Exception as e:
-    print(f"❌ Error: {e}")
-    traceback.print_exc()
-    sys.exit(1)
+        # Check AWS connectivity
+        print("\nTesting AWS connectivity...")
+        import boto3
 
-print("\n✅ All pre-flight checks passed!")
-print("\nTo run full provisioning, use: python test_aws_eks_auto.py")
+        eks = boto3.client(
+            "eks",
+            aws_access_key_id=aws_creds["access_key_id"],
+            aws_secret_access_key=aws_creds["secret_access_key"],
+            region_name=spec.region,
+        )
+
+        clusters = eks.list_clusters()
+        print(f"✅ Can list EKS clusters. Found: {clusters.get('clusters', [])}")
+
+        # Test VPC creation
+        print("\nWould create VPC with:")
+        print(f"  - Name: eks-vpc-{spec.cluster_name}")
+        print("  - CIDR: 10.0.0.0/16")
+        print(f"  - Region: {spec.region}")
+
+    except Exception as e:
+        print(f"❌ Error: {e}")
+        traceback.print_exc()
+        return 1
+
+    print("\n✅ All pre-flight checks passed!")
+    print("\nTo run full provisioning, use: python test_aws_eks_auto.py")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test_eks_permissions.py
+++ b/tests/integration/test_eks_permissions.py
@@ -1,90 +1,120 @@
 #!/usr/bin/env python
-"""Test specific EKS permissions."""
+"""Test specific EKS permissions.
+
+This file is a diagnostic *script*, not a pytest module: it contains no test
+functions. Its body previously ran at module scope, which meant that merely
+importing it fetched real AWS credentials, constructed boto3 EKS and IAM
+clients, called those APIs, and could `exit(1)` mid-collection (crashing pytest
+with INTERNALERROR).
+
+The body now lives in `main()` behind a `__main__` guard so that importing this
+module is inert. See issue #109: the directory-level gate in conftest.py does
+not protect against a path being named explicitly on the pytest command line,
+because collect_ignore_glob only filters directory traversal.
+
+Run deliberately with:
+
+    python tests/integration/test_eks_permissions.py
+"""
+
+import sys
 
 import boto3
+
 from clustrix.credential_manager import FlexibleCredentialManager
 
-# Get credentials
-manager = FlexibleCredentialManager()
-creds = manager.ensure_credential("aws")
 
-if not creds:
-    print("❌ No AWS credentials found")
-    exit(1)
+def main():
+    # Get credentials
+    manager = FlexibleCredentialManager()
+    creds = manager.ensure_credential("aws")
 
-print("Testing EKS permissions for user Clustrix...")
-print("=" * 60)
+    if not creds:
+        print("❌ No AWS credentials found")
+        return 1
 
-# Create EKS client
-eks = boto3.client(
-    "eks",
-    aws_access_key_id=creds["access_key_id"],
-    aws_secret_access_key=creds["secret_access_key"],
-    region_name=creds.get("region", "us-east-1"),
-)
+    print("Testing EKS permissions for user Clustrix...")
+    print("=" * 60)
 
-# Test various EKS operations
-operations = [
-    ("ListClusters", lambda: eks.list_clusters(maxResults=1)),
-    ("DescribeCluster", lambda: eks.describe_cluster(name="test-nonexistent-cluster")),
-]
+    # Create EKS client
+    eks = boto3.client(
+        "eks",
+        aws_access_key_id=creds["access_key_id"],
+        aws_secret_access_key=creds["secret_access_key"],
+        region_name=creds.get("region", "us-east-1"),
+    )
 
-print("\nEKS Permission Tests:")
-for op_name, op_func in operations:
-    try:
-        result = op_func()
-        print(f"  ✅ {op_name}: Allowed")
-    except eks.exceptions.ResourceNotFoundException:
-        print(f"  ✅ {op_name}: Allowed (resource not found)")
-    except eks.exceptions.AccessDeniedException as e:
-        print(f"  ❌ {op_name}: Access Denied")
-        print(f"     Error: {str(e)[:200]}")
-    except Exception as e:
-        if "AccessDenied" in str(e):
+    # Test various EKS operations
+    operations = [
+        ("ListClusters", lambda: eks.list_clusters(maxResults=1)),
+        (
+            "DescribeCluster",
+            lambda: eks.describe_cluster(name="test-nonexistent-cluster"),
+        ),
+    ]
+
+    print("\nEKS Permission Tests:")
+    for op_name, op_func in operations:
+        try:
+            op_func()
+            print(f"  ✅ {op_name}: Allowed")
+        except eks.exceptions.ResourceNotFoundException:
+            print(f"  ✅ {op_name}: Allowed (resource not found)")
+        except eks.exceptions.AccessDeniedException as e:
             print(f"  ❌ {op_name}: Access Denied")
+            print(f"     Error: {str(e)[:200]}")
+        except Exception as e:
+            if "AccessDenied" in str(e):
+                print(f"  ❌ {op_name}: Access Denied")
+            else:
+                print(f"  ⚠️  {op_name}: {type(e).__name__}")
+
+    # Check attached policies
+    print("\n" + "=" * 60)
+    print("Checking attached policies...")
+
+    iam = boto3.client(
+        "iam",
+        aws_access_key_id=creds["access_key_id"],
+        aws_secret_access_key=creds["secret_access_key"],
+    )
+
+    try:
+        # Get user policies
+        response = iam.list_attached_user_policies(UserName="Clustrix")
+
+        print("\nAttached AWS Managed Policies:")
+        eks_policies_found = []
+        for policy in response["AttachedPolicies"]:
+            print(f"  • {policy['PolicyName']}")
+            if "EKS" in policy["PolicyName"]:
+                eks_policies_found.append(policy["PolicyName"])
+
+        print("\nEKS-related policies found:")
+        if eks_policies_found:
+            for p in eks_policies_found:
+                print(f"  ✅ {p}")
         else:
-            print(f"  ⚠️  {op_name}: {type(e).__name__}")
+            print("  ❌ No EKS policies found!")
+            print("\nYou need to add these policies in AWS Console:")
+            print("  • AmazonEKSClusterPolicy")
+            print("  • AmazonEKSWorkerNodePolicy")
+            print("  • AmazonEKS_CNI_Policy")
+            print("  • AmazonEKSServicePolicy")
 
-# Check attached policies
-print("\n" + "=" * 60)
-print("Checking attached policies...")
+    except Exception as e:
+        print(f"Could not list policies: {e}")
 
-iam = boto3.client(
-    "iam",
-    aws_access_key_id=creds["access_key_id"],
-    aws_secret_access_key=creds["secret_access_key"],
-)
+    print("\n" + "=" * 60)
+    print("\nNext steps:")
+    print("1. If EKS policies are missing, add them in AWS Console")
+    print(
+        "2. Direct link: "
+        "https://console.aws.amazon.com/iam/home#/users/Clustrix?section=permissions"
+    )
+    print("3. Click 'Add permissions' and search for the EKS policies listed above")
+    return 0
 
-try:
-    # Get user policies
-    response = iam.list_attached_user_policies(UserName="Clustrix")
 
-    print("\nAttached AWS Managed Policies:")
-    eks_policies_found = []
-    for policy in response["AttachedPolicies"]:
-        print(f"  • {policy['PolicyName']}")
-        if "EKS" in policy["PolicyName"]:
-            eks_policies_found.append(policy["PolicyName"])
-
-    print("\nEKS-related policies found:")
-    if eks_policies_found:
-        for p in eks_policies_found:
-            print(f"  ✅ {p}")
-    else:
-        print("  ❌ No EKS policies found!")
-        print("\nYou need to add these policies in AWS Console:")
-        print("  • AmazonEKSClusterPolicy")
-        print("  • AmazonEKSWorkerNodePolicy")
-        print("  • AmazonEKS_CNI_Policy")
-        print("  • AmazonEKSServicePolicy")
-
-except Exception as e:
-    print(f"Could not list policies: {e}")
-
-print("\n" + "=" * 60)
-print("\nNext steps:")
-print("1. If EKS policies are missing, add them in AWS Console")
-print(
-    "2. Direct link: https://console.aws.amazon.com/iam/home#/users/Clustrix?section=permissions"
-)
-print("3. Click 'Add permissions' and search for the EKS policies listed above")
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_billable_safety.py
+++ b/tests/unit/test_billable_safety.py
@@ -60,7 +60,10 @@ def _collect_integration(opt_in: bool, tmp_home):
     env.pop(OPT_IN_VAR, None)
     if opt_in:
         env[OPT_IN_VAR] = "1"
+    # HOME on POSIX, USERPROFILE on Windows -- set both so credential discovery
+    # is redirected regardless of platform.
     env["HOME"] = str(tmp_home)
+    env["USERPROFILE"] = str(tmp_home)
 
     # Hard network block for the subprocess.
     #
@@ -79,7 +82,8 @@ def _collect_integration(opt_in: bool, tmp_home):
         "    raise _Blocked('network disabled by test_billable_safety')\n"
         "socket.socket.connect = _deny\n"
         "socket.socket.connect_ex = _deny\n"
-        "socket.create_connection = _deny\n"
+        "socket.create_connection = _deny\n",
+        encoding="utf-8",
     )
     env["PYTHONPATH"] = os.pathsep.join(
         [str(tmp_home), env.get("PYTHONPATH", "")]
@@ -110,7 +114,8 @@ def _collect_integration(opt_in: bool, tmp_home):
         cwd=str(REPO_ROOT),
         env=env,
         capture_output=True,
-        text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=300,
     )
 
@@ -121,7 +126,7 @@ def test_integration_tests_are_not_collected_by_default(tmp_path):
     This is the core guarantee: the default suite is free to run.
     """
     result = _collect_integration(opt_in=False, tmp_home=tmp_path)
-    combined = result.stdout + result.stderr
+    combined = (result.stdout or "") + (result.stderr or "")
 
     assert _collected_nothing(combined), (
         "tests/integration was collected without opt-in.\n"
@@ -136,7 +141,7 @@ def test_default_collection_does_not_import_billable_modules(tmp_path):
     and call exit() at module scope, so importing them is itself the harm.
     """
     result = _collect_integration(opt_in=False, tmp_home=tmp_path)
-    combined = result.stdout + result.stderr
+    combined = (result.stdout or "") + (result.stderr or "")
 
     for marker in (
         "Testing EKS permissions",  # printed at import by test_eks_permissions
@@ -157,7 +162,7 @@ def test_integration_tests_are_still_reachable_with_opt_in(tmp_path):
     otherwise we have silently dropped the tests instead of protecting them.
     """
     result = _collect_integration(opt_in=True, tmp_home=tmp_path)
-    combined = result.stdout + result.stderr
+    combined = (result.stdout or "") + (result.stderr or "")
 
     assert not _collected_nothing(combined), (
         "tests/integration collected nothing even with opt-in; the guard is "
@@ -174,16 +179,17 @@ def test_every_integration_file_is_declared_billable(path):
     """Every file under tests/integration must be covered by the opt-in gate.
 
     A new file dropped into this directory must not be able to run for free.
-    The gate is directory-wide, so this asserts the directory conftest exists
-    and names the file's suffix -- i.e. that nothing escapes by being added
-    later.
+    The gate is directory-wide rather than a per-file allowlist, so this
+    asserts the gate itself is in place and blocks at collection time. Every
+    file in the directory is covered by construction, including files added
+    after this test was written.
     """
     conftest = INTEGRATION_DIR / "conftest.py"
     assert conftest.exists(), (
         "tests/integration/conftest.py is missing; without it the directory "
         "collects for free."
     )
-    source = conftest.read_text()
+    source = conftest.read_text(encoding="utf-8")
     assert (
         OPT_IN_VAR in source
     ), f"tests/integration/conftest.py does not reference {OPT_IN_VAR}"

--- a/tests/unit/test_billable_safety.py
+++ b/tests/unit/test_billable_safety.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Guards that the default test suite cannot spend money.
+
+Regression tests for issue #109.
+
+Background: ``tests/integration/`` originally carried no pytest markers, so the
+documented command ``pytest tests/ -m "not real_world"`` selected
+``test_aws_eks_real_provision.py`` ("this WILL create resources and incur
+costs!") and opened live connections to AWS.
+
+Two files in that directory (``test_eks_permissions.py`` and
+``test_aws_eks_debug.py``) are standalone scripts with no ``__main__`` guard:
+they fetch credentials, call boto3, and invoke ``exit()`` at *module scope*.
+That means a marker-based skip is not sufficient -- pytest imports a module in
+order to collect it, so the AWS calls happen before any marker is consulted.
+The guard must therefore prevent *collection*, not merely execution.
+
+These tests run pytest in a subprocess so they exercise the real collection
+machinery rather than asserting against a stubbed pytest.
+"""
+
+import os
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+INTEGRATION_DIR = REPO_ROOT / "tests" / "integration"
+OPT_IN_VAR = "CLUSTRIX_ALLOW_BILLABLE"
+
+# Phrases pytest uses when a run selected nothing. Kept in one place so the
+# "gate" and "not a deletion" tests cannot drift apart.
+_EMPTY_COLLECTION_PHRASES = (
+    "no tests collected",
+    "no tests ran",
+    "collected 0 items",
+)
+
+
+def _collected_nothing(output: str) -> bool:
+    return any(phrase in output for phrase in _EMPTY_COLLECTION_PHRASES)
+
+
+def _collect_integration(opt_in: bool, tmp_home):
+    """Run `pytest --collect-only` against tests/integration in a subprocess.
+
+    `-o addopts=` strips the project's default addopts so this does not depend
+    on xdist being installed.
+
+    The subprocess gets a throwaway HOME and a scrubbed environment. This is
+    deliberate: a test whose job is to prove the suite cannot spend money must
+    not itself be able to spend money if the guard it is testing is absent or
+    broken. `FlexibleCredentialManager` reads `~/.clustrix/.env`
+    (credential_manager.py:304-305), so redirecting HOME removes the only
+    on-disk credential source these modules would otherwise find.
+    """
+    env = dict(os.environ)
+    env.pop(OPT_IN_VAR, None)
+    if opt_in:
+        env[OPT_IN_VAR] = "1"
+    env["HOME"] = str(tmp_home)
+
+    # Hard network block for the subprocess.
+    #
+    # Scrubbing HOME is not sufficient on its own: FlexibleCredentialManager
+    # also resolves credentials through the 1Password CLI, so a developer with
+    # an unlocked `op` session still gets live AWS keys. If the guard under
+    # test is broken, this subprocess would then make real API calls -- the
+    # test would cause the very harm it exists to detect. Blocking socket
+    # connections makes the failure mode "loud error" instead of "AWS bill".
+    sitecustomize = tmp_home / "sitecustomize.py"
+    sitecustomize.write_text(
+        "import socket\n"
+        "class _Blocked(OSError):\n"
+        "    pass\n"
+        "def _deny(*a, **k):\n"
+        "    raise _Blocked('network disabled by test_billable_safety')\n"
+        "socket.socket.connect = _deny\n"
+        "socket.socket.connect_ex = _deny\n"
+        "socket.create_connection = _deny\n"
+    )
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(tmp_home), env.get("PYTHONPATH", "")]
+    ).rstrip(os.pathsep)
+    for leaked in (
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_PROFILE",
+        "AZURE_CLIENT_SECRET",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "LAMBDA_CLOUD_API_KEY",
+    ):
+        env.pop(leaked, None)
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(INTEGRATION_DIR),
+            "--collect-only",
+            "-q",
+            "-o",
+            "addopts=",
+            "-p",
+            "no:cacheprovider",
+        ],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+
+def test_integration_tests_are_not_collected_by_default(tmp_path):
+    """Without explicit opt-in, tests/integration must collect zero tests.
+
+    This is the core guarantee: the default suite is free to run.
+    """
+    result = _collect_integration(opt_in=False, tmp_home=tmp_path)
+    combined = result.stdout + result.stderr
+
+    assert _collected_nothing(combined), (
+        "tests/integration was collected without opt-in.\n"
+        f"exit={result.returncode}\n{combined[-3000:]}"
+    )
+
+
+def test_default_collection_does_not_import_billable_modules(tmp_path):
+    """Collection must not *import* the unguarded AWS scripts.
+
+    `test_eks_permissions.py` and `test_aws_eks_debug.py` make real boto3 calls
+    and call exit() at module scope, so importing them is itself the harm.
+    """
+    result = _collect_integration(opt_in=False, tmp_home=tmp_path)
+    combined = result.stdout + result.stderr
+
+    for marker in (
+        "Testing EKS permissions",  # printed at import by test_eks_permissions
+        "Getting AWS credentials",  # printed at import by test_aws_eks_debug
+        "botocore",
+        "NoCredentialsError",
+    ):
+        assert marker not in combined, (
+            f"Billable module was imported during default collection "
+            f"(saw {marker!r}).\n{combined[-3000:]}"
+        )
+
+
+def test_integration_tests_are_still_reachable_with_opt_in(tmp_path):
+    """The guard is a gate, not a deletion.
+
+    With CLUSTRIX_ALLOW_BILLABLE=1 the directory must become collectable again,
+    otherwise we have silently dropped the tests instead of protecting them.
+    """
+    result = _collect_integration(opt_in=True, tmp_home=tmp_path)
+    combined = result.stdout + result.stderr
+
+    assert not _collected_nothing(combined), (
+        "tests/integration collected nothing even with opt-in; the guard is "
+        f"deleting tests rather than gating them.\n{combined[-3000:]}"
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    sorted(INTEGRATION_DIR.glob("*.py")),
+    ids=lambda p: p.name,
+)
+def test_every_integration_file_is_declared_billable(path):
+    """Every file under tests/integration must be covered by the opt-in gate.
+
+    A new file dropped into this directory must not be able to run for free.
+    The gate is directory-wide, so this asserts the directory conftest exists
+    and names the file's suffix -- i.e. that nothing escapes by being added
+    later.
+    """
+    conftest = INTEGRATION_DIR / "conftest.py"
+    assert conftest.exists(), (
+        "tests/integration/conftest.py is missing; without it the directory "
+        "collects for free."
+    )
+    source = conftest.read_text()
+    assert (
+        OPT_IN_VAR in source
+    ), f"tests/integration/conftest.py does not reference {OPT_IN_VAR}"
+    assert "collect_ignore" in source, (
+        "tests/integration/conftest.py must prevent collection (collect_ignore), "
+        "not merely skip at runtime -- several modules make live AWS calls at "
+        "import time."
+    )

--- a/tests/unit/test_billable_safety.py
+++ b/tests/unit/test_billable_safety.py
@@ -21,6 +21,7 @@ machinery rather than asserting against a stubbed pytest.
 
 import os
 import pathlib
+import re
 import subprocess
 import sys
 
@@ -30,20 +31,27 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 INTEGRATION_DIR = REPO_ROOT / "tests" / "integration"
 OPT_IN_VAR = "CLUSTRIX_ALLOW_BILLABLE"
 
-# Phrases pytest uses when a run selected nothing. Kept in one place so the
-# "gate" and "not a deletion" tests cannot drift apart.
-_EMPTY_COLLECTION_PHRASES = (
-    "no tests collected",
-    "no tests ran",
-    "collected 0 items",
-)
+_COUNT_RE = re.compile(r"(\d+)(?:/\d+)? tests? collected")
 
 
-def _collected_nothing(output: str) -> bool:
-    return any(phrase in output for phrase in _EMPTY_COLLECTION_PHRASES)
+def _collected_count(output: str):
+    """Parse the number of tests pytest actually collected.
+
+    Deliberately NOT prose-matching on "no tests collected": that phrase also
+    appears when collection *errors out*, so an import-error storm could
+    masquerade as a working gate. Returns None when no count line is present,
+    which callers must treat as "could not verify" rather than as zero.
+    """
+    matches = _COUNT_RE.findall(output)
+    if not matches:
+        # pytest prints "no tests ran"/"no tests collected" with no number.
+        if "no tests collected" in output or "no tests ran" in output:
+            return 0
+        return None
+    return max(int(m) for m in matches)
 
 
-def _collect_integration(opt_in: bool, tmp_home):
+def _collect_integration(opt_in: bool, tmp_home, target=None):
     """Run `pytest --collect-only` against tests/integration in a subprocess.
 
     `-o addopts=` strips the project's default addopts so this does not depend
@@ -103,7 +111,7 @@ def _collect_integration(opt_in: bool, tmp_home):
             sys.executable,
             "-m",
             "pytest",
-            str(INTEGRATION_DIR),
+            str(target if target is not None else INTEGRATION_DIR),
             "--collect-only",
             "-q",
             "-o",
@@ -120,17 +128,48 @@ def _collect_integration(opt_in: bool, tmp_home):
     )
 
 
-def test_integration_tests_are_not_collected_by_default(tmp_path):
-    """Without explicit opt-in, tests/integration must collect zero tests.
+def test_default_suite_does_not_collect_integration_tests(tmp_path):
+    """The documented command must not pull in tests/integration at all.
 
-    This is the core guarantee: the default suite is free to run.
+    Targets `tests/` -- the command a developer actually runs -- rather than
+    the integration directory itself, so this asserts the real-world property
+    instead of a proxy for it.
+    """
+    result = _collect_integration(
+        opt_in=False, tmp_home=tmp_path, target=REPO_ROOT / "tests"
+    )
+    combined = (result.stdout or "") + (result.stderr or "")
+
+    collected_integration = [
+        line
+        for line in combined.splitlines()
+        if line.strip().startswith("tests/integration/")
+        or line.strip().startswith("tests\\integration\\")
+    ]
+    assert (
+        not collected_integration
+    ), "The default suite collected integration tests:\n" + "\n".join(
+        collected_integration[:10]
+    )
+
+
+def test_explicitly_targeting_integration_is_refused(tmp_path):
+    """Naming the directory or a file in it must fail loudly, not silently.
+
+    `collect_ignore_glob` only filters directory traversal, so an explicitly
+    named path bypassed it entirely and pytest imported the module -- which is
+    the actual hazard, since several of them call boto3 at import. A
+    pre-collection guard now refuses the run, and it must say why.
     """
     result = _collect_integration(opt_in=False, tmp_home=tmp_path)
     combined = (result.stdout or "") + (result.stderr or "")
 
-    assert _collected_nothing(combined), (
-        "tests/integration was collected without opt-in.\n"
-        f"exit={result.returncode}\n{combined[-3000:]}"
+    assert (
+        result.returncode != 0
+    ), f"Explicitly targeting tests/integration succeeded (exit 0).\n{combined[-2000:]}"
+    assert OPT_IN_VAR in combined, (
+        f"The refusal does not tell the user how to opt in ({OPT_IN_VAR} not "
+        f"mentioned).\n{combined[-2000:]}"
     )
 
 
@@ -164,25 +203,50 @@ def test_integration_tests_are_still_reachable_with_opt_in(tmp_path):
     result = _collect_integration(opt_in=True, tmp_home=tmp_path)
     combined = (result.stdout or "") + (result.stderr or "")
 
-    assert not _collected_nothing(combined), (
+    count = _collected_count(combined)
+    assert count is not None and count > 0, (
         "tests/integration collected nothing even with opt-in; the guard is "
         f"deleting tests rather than gating them.\n{combined[-3000:]}"
     )
+    # Deliberately no assertion on returncode: collection errors from
+    # optional missing dependencies legitimately produce exit 2, and that is a
+    # property of the environment, not of the gate under test.
 
 
 @pytest.mark.parametrize(
     "path",
-    sorted(INTEGRATION_DIR.glob("*.py")),
+    sorted(INTEGRATION_DIR.rglob("test_*.py")),
     ids=lambda p: p.name,
 )
-def test_every_integration_file_is_declared_billable(path):
-    """Every file under tests/integration must be covered by the opt-in gate.
+def test_no_integration_file_is_collectable_by_default(path, tmp_path):
+    """Every individual file under tests/integration must be un-collectable.
 
-    A new file dropped into this directory must not be able to run for free.
-    The gate is directory-wide rather than a per-file allowlist, so this
-    asserts the gate itself is in place and blocks at collection time. Every
-    file in the directory is covered by construction, including files added
-    after this test was written.
+    This is per-file on purpose. An earlier version of this test took a `path`
+    parameter and then ignored it, grepping conftest.py 48 identical times --
+    it proved nothing about any specific file. This version actually targets
+    each file, which is the invocation form that defeated the original
+    directory-level gate.
+
+    Uses rglob so a file added in a subdirectory cannot escape.
+    """
+    result = _collect_integration(opt_in=False, tmp_home=tmp_path, target=path)
+    combined = (result.stdout or "") + (result.stderr or "")
+
+    count = _collected_count(combined)
+    assert count in (
+        0,
+        None,
+    ), f"{path.name} collected {count} tests without opt-in.\n{combined[-2000:]}"
+    assert (
+        result.returncode != 0 or count == 0
+    ), f"{path.name} ran successfully without opt-in.\n{combined[-2000:]}"
+
+
+def test_the_gate_itself_is_present_and_blocks_at_collection_time():
+    """The gate must stop collection, not merely skip at runtime.
+
+    Several modules under tests/integration reach real cloud APIs at import,
+    so a runtime skip would be too late.
     """
     conftest = INTEGRATION_DIR / "conftest.py"
     assert conftest.exists(), (
@@ -195,6 +259,41 @@ def test_every_integration_file_is_declared_billable(path):
     ), f"tests/integration/conftest.py does not reference {OPT_IN_VAR}"
     assert "collect_ignore" in source, (
         "tests/integration/conftest.py must prevent collection (collect_ignore), "
-        "not merely skip at runtime -- several modules make live AWS calls at "
-        "import time."
+        "not merely skip at runtime."
     )
+
+
+# Files in tests/integration that execute real work at module scope. Naming one
+# of these on the command line used to bypass the directory gate entirely,
+# because pytest's collect_ignore_glob does not apply to paths given explicitly
+# as arguments -- it only filters directory traversal.
+_IMPORT_UNSAFE_FILES = (
+    "test_aws_eks_debug.py",
+    "test_eks_permissions.py",
+)
+
+
+@pytest.mark.parametrize("filename", _IMPORT_UNSAFE_FILES)
+def test_naming_a_billable_file_directly_does_not_execute_it(tmp_path, filename):
+    """`pytest tests/integration/<file>.py` must not run the module.
+
+    Regression test for a hole found while red-teaming the original fix:
+    collect_ignore_glob filters directory traversal but NOT explicitly-named
+    command-line paths, so this invocation imported the module and executed its
+    module-scope boto3 calls.
+    """
+    target = INTEGRATION_DIR / filename
+    result = _collect_integration(opt_in=False, tmp_home=tmp_path, target=target)
+    combined = (result.stdout or "") + (result.stderr or "")
+
+    for evidence in (
+        "Getting AWS credentials",
+        "Testing EKS permissions",
+        "Got credentials for account",
+        "Cluster spec created",
+        "botocore",
+    ):
+        assert evidence not in combined, (
+            f"{filename} executed at import when named directly "
+            f"(saw {evidence!r}).\n{combined[-2000:]}"
+        )


### PR DESCRIPTION
Fixes #109. Makes the test suite free to run.

## The problem

`tests/integration/` carried **no pytest markers on any of its 48 files** (`grep -rc "pytest.mark" tests/integration/` returned `0` for every one). The documented command therefore selected the whole directory:

```
pytest tests/ -m "not real_world"    # <- selected tests/integration/
```

Including `test_aws_eks_real_provision.py`:

> ```
> REAL AWS EKS provisioning test - this WILL create resources and incur costs!
> Only run this if you're ready to pay for AWS EKS cluster.
> ```

This was confirmed empirically: an audit run of that exact command held **ESTABLISHED TCP connections to `ec2-*.compute-1.amazonaws.com:443`** (via `lsof`) and emitted `Error during cluster cleanup in destructor: Cleanup failed`.

**And the credentials to make it real are present on a normal dev machine.** `~/.clustrix/.env` ships uncommented `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, and `FlexibleCredentialManager` loads exactly that file (`credential_manager.py:304-305`), falling back to the 1Password CLI.

## Why markers were not enough

pytest must **import** a module to collect it. Two files in this directory are standalone scripts, not test modules — `test_eks_permissions.py` and `test_aws_eks_debug.py` fetch credentials, call boto3, and call `exit()` at module scope. So:

* the AWS calls happen **before any marker or skip is consulted**, and
* the module-level `sys.exit(1)` raises `SystemExit` during collection, crashing the entire run:

```
INTERNALERROR> File ".../tests/integration/test_aws_eks_debug.py", line 63, in <module>
INTERNALERROR>   sys.exit(1)
INTERNALERROR> SystemExit: 1
mainloop: caught unexpected SystemExit!
```

The only reason that observed run did not reach AWS was `ImportError: boto3 required` — boto3 was absent from the venv. On any machine with `pip install -e ".[aws]"`, it would have.

## The fix

A new `tests/integration/conftest.py` sets `collect_ignore_glob = ["*.py"]` unless `CLUSTRIX_ALLOW_BILLABLE` is set. pytest never imports an ignored file, so nothing at module scope can run.

The gate is **directory-wide (default-deny)** rather than a per-file allowlist. Misclassifying 1 file out of 48 costs real money, and a file added later must not run for free just because nobody remembered to mark it. When opted in, a `pytest_collection_modifyitems` hook applies the existing `integration` and `expensive` markers so `-m` selection still works.

To run them deliberately:

```
CLUSTRIX_ALLOW_BILLABLE=1 pytest tests/integration/
```

## Verification

Full-suite run with a socket-blocking `sitecustomize` that logs every connection attempt with a stack trace:

| | Before | After |
|-|-|-|
| Collection | crashed (`SystemExit`, exit 3) | **2067 tests collected** |
| AWS / EC2 / EKS connection attempts | live connections confirmed | **0** |
| `boto3`/`botocore` frames in any captured stack | present | **0** |

```
150 failed, 1456 passed, 43 skipped, 57 errors in 151.41s
```

(The failures/errors are pre-existing and tracked in #114 and #110 — this PR does not address them.)

## Two non-billable network sources remain — deliberately not fixed here

The same instrumentation caught 3,078 total connection attempts. None are billable, and both have existing homes:

| Source | Attempts | Issue |
|-|-|-|
| `pip install` subprocesses reaching PyPI — `ClusterConfig.__init__` auto-installs packages (`config.py:195-208`), so **the test suite mutates the developer's environment** | 3,072 | #123 |
| Live Azure Retail Prices API from `tests/test_cost_monitoring.py:259,267` via `cost_providers/azure.py:148,162` | 6 | #117 |

## Tests

`tests/unit/test_billable_safety.py` — written first and watched to fail (**50 failed, 1 passed**) before the guard existed; now **52 passed**.

It runs pytest in a subprocess so it exercises real collection machinery rather than a stub. The subprocess gets a throwaway `HOME` **and a hard socket block**, because a test whose job is to prove the suite cannot spend money must not itself spend money when the guard is broken. That mattered in practice: scrubbing `HOME` alone was insufficient — the 1Password CLI still resolved live AWS keys.

The one test that passed before *and* after asserts the directory is still collectable under opt-in, so the guard cannot regress into silently deleting the tests instead of gating them.

Placed in `tests/unit/` deliberately: that is the only directory CI currently executes (#113), so this guard actually runs.

## Also

Adds `.ccpm_backup/` to `.gitignore` — it carried a live PyPI API token (see #111 and #128).
