### PR TITLE
Update notes for handoff to a fresh session

### DIFF
--- a/notes/HANDOFF.md
+++ b/notes/HANDOFF.md
@@ -1,0 +1,160 @@
+# HANDOFF — start here
+
+**Last updated:** 2026-08-17 · **`master` @ `760432c`** · Read this before anything else in `notes/`.
+
+---
+
+## 1. Where things stand
+
+The package is mid-way through the production-readiness effort tracked by the
+master plan **#108**. The audit behind it is in
+`audit_and_master_plan_2026-08-17.md`.
+
+Two things landed today:
+
+| Issue | State | Result |
+|-|-|-|
+| **#109** billable tests cannot run by accident | closed earlier | guard + opt-in, now hardened further |
+| **#130** `pytest.ini` was dead config shadowing `pyproject.toml` | **closed** | PR #134 → `760432c` |
+
+Three issues were **filed** today and are open: **#133**, **#135**, and the
+correction comments on **#110** and **#114**.
+
+### What #130 actually changed
+
+`pytest.ini` used `[tool:pytest]`, a header valid only in `setup.cfg`. pytest
+selected the file anyway and stopped searching, so `pyproject.toml` was never
+read either — two config files, **zero** effective configuration. `addopts`,
+`testpaths`, `filterwarnings`, every marker and `--strict-markers` were all
+declared and inert.
+
+Now: `pyproject.toml` is the single source, `testpaths = ["tests"]`,
+`--strict-markers` is live, 7 markers registered, `filterwarnings` restored.
+`pytest.ini` is deleted and `tests/unit/test_pytest_config.py` fails if any
+config file ever shadows `pyproject.toml` again.
+
+---
+
+## 2. Read these in this order
+
+1. **This file.**
+2. `session_130_pytest_config_execution.md` — what was done, what was measured,
+   and a red-team section listing **two bugs that the fix itself introduced**.
+   Its "Final verified state" block is the current truth.
+3. `handoff_130_pytest_config.md` — **already executed, do not run again.** It
+   carries a banner saying so. Kept for its analysis; two of its instructions
+   were wrong and were reversed.
+4. `audit_and_master_plan_2026-08-17.md` — the #108 background.
+
+---
+
+## 3. Environment — read before running anything
+
+**The repo has no usable venv and `import clustrix` fails everywhere by
+default** (`paramiko` missing). This is #110 and it is still open. Build a
+throwaway one:
+
+```bash
+python3 -m venv /tmp/v && /tmp/v/bin/pip install -e ".[dev]"
+/tmp/v/bin/pytest tests/unit/ -q          # expect: 79 passed
+```
+
+`[dev]` is now sufficient to collect the whole tree (`numpy`/`pandas` were
+added). Add `pytest-xdist pytest-timeout` only if you need them.
+
+Gotchas that will cost you time:
+
+- **`scripts/pre_push_check.py` shells out to bare `pytest`/`mypy`/`flake8`
+  from `PATH`.** Run it as
+  `PATH="/tmp/v/bin:$PATH" /tmp/v/bin/python scripts/pre_push_check.py`.
+  Using the venv interpreter alone fails with `ModuleNotFoundError: paramiko`.
+- **That script cannot exit 0** — flake8 reports 91 findings on `master`. This
+  is #133, not something you broke. CI runs the same flake8 command with
+  `--exit-zero`, so it has never been green anywhere.
+- **`tomllib` needs Python ≥3.11.** Default interpreter here is 3.9; use
+  `/opt/homebrew/bin/python3.12`.
+- **Pass `-o addopts=`** when comparing collection counts across changes.
+- **`tests/real_world/conftest.py:223`** calls `is_dartmouth_network()` at
+  collection time — live DNS plus a `ping`. If collection hangs off-network,
+  that is why. Tracked as #117.
+- **CI's `black` is pinned to 25.1.0.** Do not "upgrade" it (see #110).
+- GitHub's API returned 503s repeatedly today; `gh pr edit` also fails with a
+  Projects-classic GraphQL deprecation error. Use
+  `gh api -X PATCH repos/ContextLab/clustrix/pulls/<n> -F body=@file.md`.
+
+---
+
+## 4. ⚠️ The one thing not to break
+
+`tests/integration/` provisions **real, billable** AWS EKS/EC2 resources. Two
+layers stop it:
+
+1. `tests/conftest.py::pytest_configure` refuses any run whose targets resolve
+   under `tests/integration`.
+2. `tests/integration/conftest.py` sets `collect_ignore_glob` so pytest never
+   imports anything there.
+
+Opt in deliberately with `CLUSTRIX_ALLOW_BILLABLE=1`.
+
+**The guard reads `config.args`, not `config.invocation_params.args`. Do not
+"simplify" this.** `invocation_params.args` is only what the operator typed;
+`testpaths`, `-o testpaths=` and `PYTEST_ADDOPTS` all feed `config.args`
+without appearing in it. Narrowing the guard opened two working money-safety
+bypasses during this PR, caught only by red-teaming.
+
+Reading `config.args` is safe **only because `testpaths = ["tests"]`**. If you
+ever put `tests/integration` back into `testpaths`, a bare `pytest` will be
+refused and the whole suite becomes unrunnable. The two settings are coupled;
+`tests/unit/test_billable_safety.py` (60 tests) enforces the coupling.
+
+---
+
+## 5. Suggested next steps, in priority order
+
+1. **#121 — P0 security.** Unauthenticated pickle of remote results (RCE) plus
+   disabled SSH host-key verification. The only P0 that is a live exploit
+   rather than hygiene. Start here unless told otherwise.
+2. **#114 — re-baseline the failures.** Now genuinely actionable for the first
+   time: collection used to abort on a SyntaxError, so its "127 failures /
+   8 collection errors" was measured while 6 modules could not be imported.
+   Collection errors are now **0**. A partial run showed 13 failures in the
+   first 59 tests; the real number is unknown. Re-derive, then triage.
+3. **#135 + #133 together.** Both are "a gate that silently does nothing" —
+   the same failure mode as #130. `fast_ci.yml` is invalid YAML and has never
+   run a single job (on `master` too); `pre_push_check.py` can never pass.
+   Sequence #135 against #120, since its integration job runs real `@cluster`
+   execution and may fail legitimately.
+4. **#110 — finish it.** Two of its acceptance criteria are met (f-string
+   SyntaxError fixed; `numpy`/`pandas` declared). Still open: `pytest-xdist`
+   placement, the `requires-python` floor, a documented bootstrap, and a CI job
+   that installs only `[dev]` and asserts collection succeeds.
+
+---
+
+## 6. Working agreements established in these sessions
+
+- **Do not hand PRs back for review.** The instruction on record is: *"this is
+  too early for a serious review; you should review both PRs and merge or edit
+  as you see fit. use subagents to red-team and do this carefully. then suggest
+  next steps."* Red-team, fix, merge, then propose what is next.
+- **Red-teaming is not optional and it works.** Four agents found two bugs the
+  fix itself had introduced, including a money-safety regression. Budget for it.
+- **Do not take subagent findings on trust.** Of four reports, one claim was
+  wrong (it inspected the wrong venv) and one misattributed a cause. Verify
+  before acting.
+- **Fix what you encounter, but do not smuggle it into an unrelated PR.** The
+  f-string SyntaxError and the `numpy`/`pandas` gap were fixed because they
+  blocked the #130 gate. The dead `fast_ci.yml` workflow and the 91 flake8
+  findings were filed instead, because repairing them has unpredictable blast
+  radius.
+
+---
+
+## 7. Loose ends in the working tree
+
+- `.omc/` — tooling state, untracked, ignore it.
+- `coverage_detailed_report.txt` — stale, untracked, **nothing in the repo
+  generates it**. Safe to delete; left in place rather than presume.
+- `/tmp/v130` and `/tmp/fresh130` — throwaway venvs from today. `fresh130` is
+  `[dev]`-only and useful for checking what a clean contributor install does.
+  Both are disposable.

--- a/notes/handoff_130_pytest_config.md
+++ b/notes/handoff_130_pytest_config.md
@@ -1,5 +1,24 @@
 # Handoff: fix #130 — pytest.ini is dead config shadowing pyproject.toml
 
+> ## ✅ EXECUTED AND MERGED — 2026-08-17. Do not run this plan again.
+>
+> Landed as PR #134, squashed to `760432c` on `master`. Issue #130 is closed.
+> Outcome, corrections, and what this plan got wrong: `session_130_pytest_config_execution.md`.
+>
+> **This document is kept for its analysis, not as a to-do list.** Two of its
+> instructions were wrong and were reversed during execution:
+>
+> 1. **Step 1's core recommendation is unsafe.** It says to switch the #109
+>    guard to `config.invocation_params.args`. Doing so opens real
+>    money-safety bypasses (`PYTEST_ADDOPTS=`, `-o testpaths=`), because what
+>    the operator types is not what pytest collects. The guard reads
+>    `config.args` on `master` today; that is safe only because Step 2's
+>    `testpaths = ["tests"]` also landed. Do not "restore" Step 1 as written.
+> 2. **Step 0's baseline was not clean.** It had 6 collection errors that had
+>    to be fixed before Step 4's gate could mean anything.
+>
+> Its §8 "Things that will trip you up" is still accurate and still useful.
+
 **Written:** 2026-08-17 · **For:** a fresh session picking this up cold
 **Issue:** ContextLab/clustrix#130 · **Parent:** #108 · **Related:** #110, #113, #115, #117
 

--- a/notes/session_130_pytest_config_execution.md
+++ b/notes/session_130_pytest_config_execution.md
@@ -1,7 +1,10 @@
 # Session log: executing the #130 plan
 
-**Date:** 2026-08-17 · **Branch:** `fix/130-pytest-config` · **Base:** `master` @ `a9393b7`
-**Plan followed:** `notes/handoff_130_pytest_config.md`
+**Date:** 2026-08-17 · **Merged:** PR #134 → `760432c` on `master` · **Issue #130: closed**
+**Base:** `master` @ `a9393b7` · **Plan followed:** `notes/handoff_130_pytest_config.md`
+
+> Read `HANDOFF.md` first if you are a fresh session. This file is the detailed
+> record; `HANDOFF.md` is the entry point.
 
 Every command below was run in a throwaway venv, since the repo has no usable
 one by default (#110):
@@ -60,20 +63,34 @@ So the two fixes are each independently sufficient, and the test guards the
 *combination*. Both are kept as belt and braces, and the table is recorded in
 the test's docstring.
 
+> **Superseded — see the red-team section below.** That table is about one
+> property only (does bare `pytest` run?). It is true as far as it goes and
+> badly misleading as a conclusion: `invocation_params.args` also opens real
+> money-safety bypasses, so the two options were never equivalent. The guard
+> reads `config.args` on `master` today.
+
 **`--strict-markers` needs care with `-o addopts=`.** It reaches pytest through
 `addopts`, so `test_strict_markers_is_active` skips when
 `config.option.override_ini` contains an `addopts=` entry. Verified against
 pytest 8.4.2: that attribute holds `['addopts=']`.
 
-**`pre_push_check.py` ran a bare `pytest`.** Harmless only while no config was
-effective. Once `testpaths` went live it resolved to all 1670 tests including
-the 224 network-bound ones in `tests/real_world/`, and stopped terminating. It
+**`pre_push_check.py` ran a bare `pytest`.** (Two figures in this paragraph
+were wrong when first written and are corrected here: it was never "harmless",
+and `tests/real_world/` holds 388 tests, not 224 — that was a count of
+decorator lines.) On `master` the bare `pytest` aborted in seconds on the
+f-string SyntaxError and ran **zero** tests, so the gate was permanently red
+and checked nothing. Fixing that error let collection succeed, at which point
+the bare `pytest` resolved to all 1670 tests including the 388 network-bound
+ones in `tests/real_world/`, and stopped terminating. It
 also left artifacts behind: it modified checked-in files under
 `tests/real_world/screenshots/` and created an untracked
 `performance_test_results/`. Now runs `pytest tests/unit/ -m "not real_world"`,
 matching `.github/workflows/tests.yml`; the generated paths are gitignored.
 
-## Definition of done — measured
+## Definition of done — measured *at the time the PR was opened*
+
+Superseded by the "Final verified state" block at the end of this file; the
+counts moved once the red-team fixes added tests. Kept for the audit trail.
 
 ```
 configfile                                       pyproject.toml
@@ -110,3 +127,104 @@ https://github.com/ContextLab/clustrix/issues/110#issuecomment-5317453905
 
 **#117** untouched, as instructed — `tests/real_world/conftest.py:223` still
 calls `is_dartmouth_network()` at collection time.
+
+---
+
+# Red-team pass (after the PR was opened)
+
+Four parallel subagents were pointed at the branch: guard bypasses, config
+regressions, the new tests, and PR-claim honesty. **Two of the bugs they found
+were mine, introduced by this PR.** Everything below was fixed before merge.
+
+## 1. Step 1 of the plan was actively unsafe (the important one)
+
+Switching the #109 guard to `config.invocation_params.args` unblocked bare
+`pytest`, but `invocation_params.args` is only *what the operator typed*.
+`testpaths`, `-o testpaths=` and `PYTEST_ADDOPTS` all feed `config.args`
+without ever appearing there. Verified against `master`, which **refused** both:
+
+```bash
+PYTEST_ADDOPTS=tests/integration/test_timeout_mechanism.py pytest --co   # branch: 2 collected
+pytest --co -o testpaths=tests/integration/test_timeout_mechanism.py     # branch: 2 collected
+```
+
+**Resolution: the fix belonged in the config, not the guard.** The guard reads
+`config.args` again — safe *because* `testpaths = ["tests"]` landed in Step 2.
+
+Also fixed while in there (both pre-existing #109 holes):
+
+- relative paths were resolved only against `rootdir`, so from inside `tests/`
+  the path `integration/test_x.py` was unrecognised. All plausible bases are
+  tried now.
+- `--pyargs` / `-p` address modules by dotted name and never looked like paths;
+  both are translated and checked.
+
+Final state, measured:
+
+| invocation | result |
+|-|-|
+| explicit dir / file / node id | refused |
+| `-o testpaths=` | refused |
+| `PYTEST_ADDOPTS=` | refused |
+| `--pyargs <dotted>` | refused |
+| cwd-relative from `tests/` | refused |
+| bare `pytest` | allowed, **0** integration nodes |
+| `CLUSTRIX_ALLOW_BILLABLE=1` | works |
+
+`-p <dotted>` cannot be blocked *before* the import it triggers — no conftest
+hook runs that early — but the run is refused before any test executes, which
+is where the cost is. It also fails on its own here: `tests/` is not a package.
+
+Covered by `test_indirect_targeting_of_integration_is_refused` (4 params).
+Three of the four fail against the old guard, so they are not decorative.
+
+## 2. Claims of mine that were false
+
+- **"the 224 tests in tests/real_world/"** — wrong, and I had committed it as a
+  code comment. 224 counts `@pytest.mark.real_world` *decorator lines*; the
+  directory collects **388** tests.
+- **The `pre_push_check.py` rationale** — I wrote that bare `pytest` was
+  "harmless while no config applied." It was not: on `master` it aborted in
+  seconds on the f-string SyntaxError and ran **zero** tests. Fixing that error
+  is what made the runtime problem appear.
+- **`test_no_shadowing_config_file_exists` forbade `tox.ini`/`setup.cfg`** —
+  pytest checks both *after* `pyproject.toml` (`_pytest/config/findpaths.py`),
+  so neither can shadow it, and the test failed on an ordinary pytest-free
+  `setup.cfg` holding flake8 config. Now limited to `pytest.ini`/`.pytest.ini`.
+- **`coverage_detailed_report.txt` in `.gitignore`** — nothing in the repo
+  writes it. Entry removed.
+- **"18/18 CI checks passing"** — incomplete. `gh pr checks` omits the Fast CI
+  workflow, which was running and failing.
+
+One agent claim was **rejected**: it reported the fresh-venv result as
+unsubstantiated, having inspected `/tmp/v130` (which also has `[test]`).
+`/tmp/fresh130` is genuinely `[dev]`-only. Do not take agent findings on
+trust — two of the four needed verification before acting.
+
+## 3. `fast_ci.yml` — my fix was reverted, diagnosis was wrong
+
+I added `pytest-timeout` and claimed it fixed a job "failing on every run."
+It does not. The workflow is **invalid YAML and has never run a single job**
+— every run, on `master` too, is `conclusion: failure` with `jobs: 0`.
+
+```
+yaml.scanner.ScannerError: while scanning a simple key
+  in ".github/workflows/fast_ci.yml", line 89, column 1
+```
+
+Three steps open `python -c "` inside a `run: |` block and write the Python
+body at column 0, ending the block scalar. Reverted to match `master` exactly
+and filed as **#135**; the missing `pytest-timeout` is real but latent.
+
+## Final verified state on `master` @ `760432c`
+
+```
+configfile                  pyproject.toml
+bare pytest                 1674 collected, 0 integration nodes
+collection errors           0
+markers registered          7 / 7
+tests/unit/                 79 passed
+mypy                        clean
+flake8                      91 (master before: 92) -- see #133
+CI                          15 test jobs + docs + integration pass
+```


### PR DESCRIPTION
Documentation only — no code changes.

Adds `notes/HANDOFF.md` as the entry point for a fresh session, and reconciles the two existing notes now that #130 is merged.

**Why this is not just an addition.** A fresh session reading `notes/` would have found `handoff_130_pytest_config.md` and re-run a plan that is already executed — and two of that plan's instructions were wrong. It now carries an EXECUTED banner naming both.

The session log also contradicted itself once the red-team section was appended, so three claims in its earlier text are corrected in place: the "224 tests in tests/real_world/" figure (it is 388 — 224 counts decorator lines), the claim that a bare `pytest` was harmless while no config applied (it aborted on master and ran zero tests), and a table implying the two candidate guard fixes were interchangeable (only one is safe).

Verified on master @ `760432c`: tests/unit/ 79 passed, test_billable_safety 60 passed, flake8 91, #130 closed, #133/#135 open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gTBDPK16HUZ3kHQ2QyjuU